### PR TITLE
Update OMF MDS link

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Standards currently identified as being relevant for the purpose of data collect
 * [DATEXII](https://datex2.eu/)
 * [GBFS](https://github.com/MobilityData/gbfs)
 * [GTFS-Realtime](https://github.com/google/transit/tree/master/gtfs-realtime/spec/en)
-* [MDS](https://github.com/openmobilityfoundation/mds-core)
+* [MDS](https://github.com/openmobilityfoundation/mobility-data-specification)
 * [NeTEx](https://github.com/NeTEx-CEN/NeTEx)
 * [SIRI](https://www.siri-cen.eu/)
 * [TOMP-API](https://github.com/TOMP-WG/TOMP-API)


### PR DESCRIPTION
Hello. I just wanted to update the MDS link to point to our Open Mobility Foundation MDS GitHub repository.